### PR TITLE
switch to the sonLib in comparativeGenomicsToolkit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/sonLib"]
 	path = submodules/sonLib
-	url = https://github.com/benedictpaten/sonLib.git
+	url = https://github.com/comparativeGenomicsToolkit/sonLib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/sonLib"]
 	path = submodules/sonLib
-	url = https://github.com/comparativeGenomicsToolkit/sonLib.git
+	url = https://github.com/ComparativeGenomicsToolkit/sonLib.git

--- a/impl/line_iterator.c
+++ b/impl/line_iterator.c
@@ -8,7 +8,7 @@ struct _LI {
 LI *LI_construct(FILE *fh) {
     LI *li = st_calloc(1, sizeof(LI));
     li->fh = fh;
-    li->line = li->line = stFile_getLineFromFile(fh);
+    li->line = stFile_getLineFromFile(fh);
     return li;
 }
 


### PR DESCRIPTION
This needs to happen in order for it to be integrated into cactus.  

Also, you should use this sonLib all the time (or at least keep yours synced). 

Also, to avoid a similar situation with taf, I'd suggest moving this repo to ComparativeGenomicsToolkit.  The "benedictpaten" url will remain valid (and can be used on git command line) I think forever.  Everything will just redirect automatically to ComparativeGenomicsToolkit.  To do this, you go to "Settings" in this rep, scroll down to the "danger zone" then "transfer ownership".  
